### PR TITLE
JSON ADT, with prettyPrint interpreters

### DIFF
--- a/json/src/main/scala/Json.scala
+++ b/json/src/main/scala/Json.scala
@@ -1,1 +1,71 @@
 package com.jpmc.json
+
+sealed trait Json extends Product with Serializable
+
+object Json {
+  case object JNull extends Json
+  final case class JString(value: String) extends Json
+  final case class JInt(value: Int) extends Json
+  final case class JDouble(value: Double) extends Json
+  final case class JBool(value: Boolean) extends Json
+  sealed trait JDoc extends Json
+  final case class JArray(value: List[Json]) extends JDoc
+  final case class JObj(value: Map[String, Json]) extends JDoc
+
+  // overloaded apply for each of the types
+  def apply(value: String): Json = JString(value)
+  def apply(value: Int): Json = JInt(value)
+  def apply(value: Double): Json = JDouble(value)
+  def apply(value: Boolean): Json = JBool(value)
+  def apply(value: List[Json]): JDoc = JArray(value)
+  def apply(value: Map[String, Json]): JDoc = JObj(value)
+
+
+  def prettyPrint(v: Json): String = {
+    v match {
+      case JNull => "null"
+      case JString(value) => "\"" + value + "\""
+      case JInt(value) => s"$value"
+      case JDouble(value) => s"$value"
+      case JBool(value) => s"$value"
+      case z: JDoc => prettyPrintDoc(z)
+    }
+  }
+
+  def prettyPrintSkipNull(v: Json): Option[String] = {
+    v match {
+      case JNull => None
+      case JString(value) => Some("\"" + value + "\"")
+      case JInt(value) => Some(s"$value")
+      case JDouble(value) => Some(s"$value")
+      case JBool(value) => Some(s"$value")
+      case z: JDoc => Some(prettyPrintDocRemoveNulls(z))
+    }
+  }
+
+  def prettyPrintDoc(v: JDoc): String = {
+    v match {
+      case JArray(value) => "[" + value.map(prettyPrint).mkString(", ") + "]"
+      case JObj(value) => value.toList.map {
+        case (key, value) => "\"" + key + "\": " + prettyPrint(value)
+      }.mkString("{", ",", "}")
+    }
+  }
+
+  def prettyPrintDocRemoveNulls(v: JDoc) = {
+    v match {
+      case JArray(value) => "[" +
+        value.filter(x => x != JNull)
+          .map(prettyPrintSkipNull)
+          .filter(_.isDefined)
+          .map(_.get)
+          .mkString(", ") +
+        "]"
+      case JObj(value) => value.toList.filter {
+        case (_, value) => value != JNull
+      }.map {
+        case (key, value) => prettyPrintSkipNull(value).map("\"" + key + "\": " + _)
+      }.filter(_.isDefined).map(_.get).mkString("{", ", ", "}")
+    }
+  }
+}

--- a/json/src/test/scala/JsonTests.scala
+++ b/json/src/test/scala/JsonTests.scala
@@ -1,13 +1,35 @@
 package com.jpmc.json
 
+import com.jpmc.json.Json.{JNull, prettyPrintDoc, prettyPrintDocRemoveNulls}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class JsonTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
-  test("Some test") {
-    forAll { str: String =>
-      str should be(str)
-    }
+class JsonTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers with TestHelper {
+  test("prettyPrint with nulls") {
+    prettyPrintDoc(jsonData) should be(
+      """{"name": "Jason","age": 13,"accounts": [122, null],"address": {"number": 29,"city": "City of JSON","country": "Serial Country","county": null,"street": "Jason St"}}"""
+    )
   }
+
+  test("prettyPrint without nulls") {
+    prettyPrintDocRemoveNulls(jsonData) should be(
+      """{"name": "Jason", "age": 13, "accounts": [122], "address": {"number": 29, "city": "City of JSON", "country": "Serial Country", "street": "Jason St"}}"""
+    )
+  }
+}
+
+trait TestHelper {
+  val jsonData: Json.JDoc = Json(Map(
+    "name" -> Json("Jason"),
+    "age" -> Json(13),
+    "accounts" -> Json(List(Json(122), JNull)),
+    "address" -> Json(Map(
+      "number" -> Json(29),
+      "street" -> Json("Jason St"),
+      "city" -> Json("City of JSON"),
+      "county" -> JNull,
+      "country" -> Json("Serial Country")
+    ))
+  ))
 }


### PR DESCRIPTION
- `prettyPrint` - the widest interpreter
- `prettyPrintDoc` - interpreter which only works with Json Documents
- `prettyPrintSkipNull` - returns an Optional prettyPrint string value skipping nulls
- `prettyPrintDocRemoveNulls` - doc interpreter which removes JSON key entries which have null in the values