### PR TITLE
Decoders Implementation for JSON Decoding and respective tests

### DIFF
--- a/codecs/src/main/scala/Decoder.scala
+++ b/codecs/src/main/scala/Decoder.scala
@@ -1,1 +1,132 @@
 package com.jpmc.codecs
+
+import com.jpmc.codecs.Decoder.DecoderResult
+import com.jpmc.codecs.Encoder.User
+import com.jpmc.json.Json
+
+import java.time.LocalDate
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+case class DecoderErr(message: String)
+trait Decoder[A] {
+  def map[B](f: A => B): Decoder[B] = Decoder.from { j =>
+    this.decode(j).map(f)
+  }
+  def decode(value: Json): DecoderResult[A]
+  // Json to an Either[String, A]
+  def withErr(message: String): Decoder[A] = Decoder.from { json =>
+    decode(json).left.map(_ => DecoderErr(message))
+  }
+}
+
+object Decoder {
+  type DecoderResult[A] = Either[DecoderErr, A]
+  def apply[A](implicit decoder: Decoder[A]): Decoder[A] = decoder
+
+  def from[A](f: Json => DecoderResult[A]): Decoder[A] = (j: Json) => f(j)
+
+  private def fromPartial[A](pf: PartialFunction[Json, DecoderResult[A]]): Decoder[A] = (j: Json) =>
+    pf.lift.apply(j) match {
+      case Some(json) => json
+      case None => Left(DecoderErr("No decoder found, match error."))
+    }
+
+  implicit class DecoderOps(value: Json) {
+    def as[A](implicit decoder: Decoder[A]): DecoderResult[A] = decoder.decode(value)
+  }
+  implicit class DocDecoderOps(jsonObj: Json.Object) {
+    def decodeMap[A](key: String)(implicit decoder: Decoder[A]): DecoderResult[A] =
+      jsonObj.data.get(key)
+        .toRight(DecoderErr(s"Unable to find value at key = ${key}"))
+        .flatMap(_.as[A])
+  }
+
+  implicit val stringDecoder: Decoder[String] = fromPartial {
+    case Json.String(str) => Right(str)
+  }.withErr("Could not decode String")
+
+  implicit val intDecoder: Decoder[Int] = fromPartial {
+    case Json.Number(num) => Right(num)
+  }.withErr("Could not decode Int")
+
+  implicit val boolDecoder: Decoder[java.lang.Boolean] = fromPartial {
+    case Json.Boolean(bool) => Right(bool)
+  }.withErr("Could not decode Boolean")
+
+  implicit val dateDecoder: Decoder[LocalDate] = fromPartial {
+    case Json.String(str) => Try(LocalDate.parse(str)) match {
+      case Failure(exp) => Left(DecoderErr(s"Failure to parse Local date time: ${str}, with exception ${exp.getMessage}"))
+      case Success(value) => Right(value)
+    }
+  }
+
+  implicit def tuple2Decoder[A: Decoder, B: Decoder]: Decoder[Tuple2[A, B]] = fromPartial {
+    case obj: Json.Object => for {
+      val1 <- obj.decodeMap[A]("1")
+      val2 <- obj.decodeMap[B]("2")
+    } yield (val1, val2)
+  }.withErr("Could not decode Tuple 2")
+
+  implicit def tuple3Decoder[A: Decoder, B: Decoder, C: Decoder]: Decoder[Tuple3[A, B, C]] = fromPartial {
+    case obj: Json.Object => for {
+      val1 <- obj.decodeMap[A]("1")
+      val2 <- obj.decodeMap[B]("2")
+      val3 <- obj.decodeMap[C]("3")
+    } yield (val1, val2, val3)
+  }.withErr("Could not decode Tuple 3")
+
+  implicit def eitherDecoder[A: Decoder, B: Decoder]: Decoder[Either[A, B]] = fromPartial {
+    case Json.Object(m) if m.contains("left") =>
+      m.get("left").toRight(DecoderErr("Failed to get Left value")).flatMap(_.as[A]).map(Left(_))
+    case Json.Object(m) if m.contains("right") =>
+      m.get("right").toRight(DecoderErr("Failed to get Right value")).flatMap(_.as[B]).map(Right(_))
+  }
+
+  implicit def optionDecoder[A: Decoder]: Decoder[Option[A]] = fromPartial {
+    case Json.Null => Right(Option.empty[A])
+    case j: Json =>
+      j.as[A].map(Option.apply)
+  }.withErr(s"Could not decode Option")
+
+  // Going from F[G[A]] to G[F[A]]
+  // F = List
+  // G = DecoderResult
+  implicit def listDecoder[A: Decoder]: Decoder[List[A]] = fromPartial {
+    case Json.Array(data) =>
+      @tailrec
+      def loop(resList: List[DecoderResult[A]], acc: DecoderResult[List[A]]): DecoderResult[List[A]] = {
+        resList match {
+          case Nil => acc
+          case head :: tail =>
+            val accumulating = for {
+              al <- acc
+              a <- head
+            } yield a :: al
+            loop(tail, accumulating)
+        }
+      }
+      val resList = data.map(json => json.as[A]) // give me a list of Decoded Results
+      val initialList = List.empty[A]
+      loop(resList, Right(initialList).map(_.reverse))
+  }.withErr("Could not decode Json Array to List")
+
+  implicit def vectorDecoder[A: Decoder]: Decoder[Vector[A]] = listDecoder[A].withErr("Could not decode Json Array to Vector").map(_.toVector)
+
+  implicit val userDecoder: Decoder[User] = fromPartial {
+    case o: Json.Object => for {
+      name <- o.decodeMap[String]("name")
+      age <- o.decodeMap[Int]("age")
+      kind <- o.decodeMap[User.Kind]("kind")
+    } yield User(name, age, kind)
+  }.withErr("Could not decode Json Object to User")
+
+  implicit val kindDecoder: Decoder[User.Kind] = fromPartial {
+    case Json.String(str) =>
+      str match {
+        case "Privileged" => Right(User.Kind.Privileged)
+        case "Normal" => Right(User.Kind.Normal)
+        case "Guest" => Right(User.Kind.Guest)
+        case _ => Left(DecoderErr("Unable to decode to Kind"))
+      }
+  }
+}

--- a/codecs/src/main/scala/Encoder.scala
+++ b/codecs/src/main/scala/Encoder.scala
@@ -1,1 +1,84 @@
 package com.jpmc.codecs
+
+import com.jpmc.json._
+
+import java.time.LocalDate
+
+trait Encoder[A] {
+  def encode(value: A): Json
+}
+
+object Encoder {
+  def apply[A](implicit encoder: Encoder[A]): Encoder[A] = encoder
+
+  def from[A](f: A => Json): Encoder[A] = (a: A) => f(a)
+
+  implicit class EncoderOps[A](a: A) {
+    def asJson(implicit encoder: Encoder[A]): Json = encoder.encode(a)
+  }
+  def encode[A](value: A)(implicit encoder: Encoder[A]): Json = {
+    encoder.encode(value)
+  }
+
+  implicit val stringEncoder: Encoder[java.lang.String] = from(Json.String)
+  implicit val intEncoder: Encoder[scala.Int] = from(Json.Number)
+  implicit val boolEncoder: Encoder[scala.Boolean] = from(bool => Json.Boolean(bool))
+  implicit val dateEncoder: Encoder[LocalDate] = from(date => Json.String(date.toString))
+
+  implicit def optionEncoder[A: Encoder]: Encoder[Option[A]] = {
+    case Some(value) => value.asJson
+    case None => Json.Null
+  }
+
+  implicit def listEncoder[A: Encoder]: Encoder[List[A]] = from { data =>
+    Json.Array(data.map(_.asJson))
+  }
+
+  implicit def vectorEncoder[A: Encoder]: Encoder[Vector[A]] = from { data =>
+    Json.Array(data.map(_.asJson).toList)
+  }
+
+  implicit def tuple2Encoder[A: Encoder, B: Encoder]: Encoder[Tuple2[A, B]] = from {
+    tup =>
+      Json.Object(
+        Map("1" -> tup._1.asJson,
+            "2" -> tup._2.asJson
+        ))
+  }
+
+  implicit def tuple3Encoder[A: Encoder, B: Encoder, C: Encoder]: Encoder[Tuple3[A, B, C]] = from {
+    tup =>
+      Json.Object(
+        Map("1" -> tup._1.asJson,
+            "2" -> tup._2.asJson,
+            "3" -> tup._3.asJson
+        ))
+  }
+
+  implicit def eitherEncoder[A: Encoder, B: Encoder]: Encoder[Either[A, B]] = {
+    case Right(value) => Json.Object(Map("right" -> value.asJson))
+    case Left(value)  => Json.Object(Map("left" -> value.asJson))
+  }
+
+  implicit val kindEncoder: Encoder[User.Kind] = {
+    case User.Kind.Privileged => Json.String("Privileged")
+    case User.Kind.Normal => Json.String("Normal")
+    case User.Kind.Guest => Json.String("Guest")
+  }
+
+  implicit val userEncoder: Encoder[User] = from { user => {
+    Json.Object(Map("name" -> user.name.asJson, "age" -> user.age.asJson, "kind" -> user.kind.asJson))
+  }}
+
+  case class User(name: java.lang.String, age: Int, kind: User.Kind)
+
+  object User {
+    sealed trait Kind
+    object Kind {
+      case object Privileged extends Kind
+      case object Normal extends Kind
+      case object Guest extends Kind
+    }
+  }
+}
+

--- a/codecs/src/test/scala/DecoderTests.scala
+++ b/codecs/src/test/scala/DecoderTests.scala
@@ -1,13 +1,237 @@
 package com.jpmc.codecs
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import com.jpmc.codecs.Encoder.User
+import com.jpmc.json.Json
+import org.scalatest.freespec.AnyFreeSpec
 
-class DecoderTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
-  test("Some test") {
-    forAll { str: String =>
-      str should be(str)
+import java.time.LocalDate
+
+class DecoderTests extends AnyFreeSpec {
+  "String Decoder" - {
+    "Successful decoding" in {
+      val str = "decode me"
+      val jsonStr = Json.String(str)
+      val expected = Right(str)
+      val result = Decoder.DecoderOps(jsonStr).as[String]
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonNum = Json.Number(123)
+      val expected = Left(DecoderErr("Could not decode String"))
+      val result = Decoder.DecoderOps(jsonNum).as[String]
+      assert(result == expected)
     }
   }
+  "Int Decoder" - {
+    "Successful decoding" in {
+      val num = 123
+      val jsonNum = Json.Number(num)
+      val expected = Right(num)
+      val result = Decoder.DecoderOps(jsonNum).as[Int]
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonNum = Json.String("this is going to fail decoding")
+      val expected = Left(DecoderErr("Could not decode Int"))
+      val result = Decoder.DecoderOps(jsonNum).as[Int]
+      assert(result == expected)
+    }
+  }
+  "Bool Decoder" - {
+    "Successful decoding" in {
+      val bool = java.lang.Boolean.TRUE
+      val jsonBool = Json.Boolean(bool)
+      val expected = Right(bool)
+      val result = Decoder.DecoderOps(jsonBool).as[java.lang.Boolean]
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonNum = Json.Number(123)
+      val expected = Left(DecoderErr("Could not decode Boolean"))
+      val result = Decoder.DecoderOps(jsonNum).as[java.lang.Boolean]
+      assert(result == expected)
+    }
+  }
+  "LocalDate Decoder" - {
+    "Successful decoding" in {
+      val dateStr = LocalDate.parse("2012-10-01")
+      val date = Json.String("2012-10-01")
+      val expected = Right(dateStr)
+      val result = Decoder.DecoderOps(date).as[LocalDate]
+      assert(result == expected)
+    }
+    "Successful decoding to Left but failure to parse date" in {
+      val date = Json.String("2012-10-43-5")
+      val expected = Left(DecoderErr(s"Failure to parse Local date time: 2012-10-43-5, with exception Text '2012-10-43-5' could not be parsed, unparsed text found at index 10"))
+      val result = Decoder.DecoderOps(date).as[LocalDate]
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonNum = Json.Number(123)
+      val expected = Left(DecoderErr("No decoder found, match error."))
+      val result = Decoder.DecoderOps(jsonNum).as[LocalDate]
+      assert(result == expected)
+    }
+  }
+  "Tuple 2 Decoder" - {
+    "Successful decoding" in {
+      val jsonObj = Json.Object(Map("1" -> Json.String("value 1"), "2" -> Json.String("value 2")))
+      val expected = Right(("value 1", "value 2"))
+      val result = Decoder[(String, String)].decode(jsonObj)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonObj = Json.Object(Map("1" -> Json.String("value 1"), "2" -> Json.Number(123)))
+      val expected = Left(DecoderErr("Could not decode Tuple 2"))
+      val result = Decoder[(String, String)].decode(jsonObj)
+      assert(result == expected)
+    }
+  }
+  "Tuple 3 Decoder" - {
+    "Successful decoding" in {
+      val jsonObj = Json.Object(Map("1" -> Json.String("value 1"), "2" -> Json.String("value 2"), "3" -> Json.Number(123)))
+      val expected = Right(("value 1", "value 2", 123))
+      val result = Decoder[(String, String, Int)].decode(jsonObj)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonObj = Json.Object(Map("1" -> Json.String("value 1"), "2" -> Json.Number(123)))
+      val expected = Left(DecoderErr("Could not decode Tuple 3"))
+      val result = Decoder[(String, String, String)].decode(jsonObj)
+      assert(result == expected)
+    }
+  }
+  "Either Decoder" - {
+    "Left" - {
+      "Successful decoding" in {
+        val jsonObj = Json.Object(Map("left" -> Json.String("This is a Left")))
+        val expected = Right(Left("This is a Left"))
+        val result = Decoder[Either[String, String]].decode(jsonObj)
+        assert(result == expected)
+      }
+      "Failure decoding" in {
+        val jsonObj = Json.Object(Map("le" -> Json.String("This should not decode")))
+        val expected = Left(DecoderErr("No decoder found, match error."))
+        val result = Decoder[Either[String, String]].decode(jsonObj)
+        assert(result == expected)
+      }
+    }
+    "Right" - {
+      "Successful decoding" in {
+        val jsonObj = Json.Object(Map("right" -> Json.Number(123)))
+        val expected = Right(Right(123))
+        val result = Decoder[Either[String, Int]].decode(jsonObj)
+        assert(result == expected)
+      }
+      "Failure decoding" in {
+        val jsonObj = Json.Object(Map("re" -> Json.String("This should not decode")))
+        val expected = Left(DecoderErr("No decoder found, match error."))
+        val result = Decoder[Either[String, String]].decode(jsonObj)
+        assert(result == expected)
+      }
+    }
+  }
+  "Option Decoder" - {
+    "Successful decoding of Some value" in {
+      val json = Json.String("Hello Some")
+      val expected = Right(Some("Hello Some"))
+      val result = Decoder[Option[String]].decode(json)
+      assert(result == expected)
+    }
+    "Successful decoding of None value" in {
+      val json = Json.Null
+      val expected = Right(Option.empty[String])
+      val result = Decoder[Option[String]].decode(json)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val json = Json.Number(123)
+      val expected = Left(DecoderErr("Could not decode Option"))
+      val result = Decoder[Option[String]].decode(json)
+      assert(result == expected)
+    }
+  }
+  "List Decoder" - {
+    "Successful decoding" in {
+      val jsonArr = Json.Array(List(Json.String("entry 1"), Json.String("entry 2")))
+      val expected = Right(List("entry 1", "entry 2"))
+      val result = Decoder[List[String]].decode(jsonArr)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonArr = Json.Array(List(Json.String("entry 1"), Json.String("entry 2"), Json.Number(1)))
+      val expected = Left(DecoderErr("Could not decode Json Array to List"))
+      val result = Decoder[List[String]].decode(jsonArr)
+      assert(result == expected)
+    }
+  }
+  "Vector Decoder" - {
+    "Successful decoding" in {
+      val jsonArr = Json.Array(List(Json.String("entry 1"), Json.String("entry 2")))
+      val expected = Right(Vector("entry 1", "entry 2"))
+      val result = Decoder[Vector[String]].decode(jsonArr)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val jsonArr = Json.Array(List(Json.String("entry 1"), Json.String("entry 2"), Json.Number(1)))
+      val expected = Left(DecoderErr("Could not decode Json Array to Vector"))
+      val result = Decoder[Vector[String]].decode(jsonArr)
+      assert(result == expected)
+    }
+  }
+  "User Decoder" - {
+    "Successful decoding" in {
+      val jsonObj = Json.Object(Map("name" -> Json.String("Mon"), "age" -> Json.Number(24), "kind" -> Json.String("Normal")))
+      val expected = Right(User("Mon", 24, User.Kind.Normal))
+      val result = Decoder[User].decode(jsonObj)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val str = Json.String("This is not a user.")
+      val expected = Left(DecoderErr("Could not decode Json Object to User"))
+      val result = Decoder[User].decode(str)
+      assert(result == expected)
+    }
+  }
+  "User Kind Decoder" - {
+    "Successful decoding of Privileged" in {
+      val str = Json.String("Privileged")
+      val expected = Right(User.Kind.Privileged)
+      val result = Decoder.DecoderOps(str).as[User.Kind]
+      assert(result == expected)
+    }
+    "Successful decoding of Guest" in {
+      val str = Json.String("Guest")
+      val expected = Right(User.Kind.Guest)
+      val result = Decoder[User.Kind].decode(str)
+      assert(result == expected)
+    }
+    "Successful decoding of Normal" in {
+      val str = Json.String("Normal")
+      val expected = Right(User.Kind.Normal)
+      val result = Decoder[User.Kind].decode(str)
+      assert(result == expected)
+    }
+    "Failure decoding" in {
+      val str = Json.String("Other")
+      val expected = Left(DecoderErr("Unable to decode to Kind"))
+      val result = Decoder[User.Kind].decode(str)
+      assert(result == expected)
+    }
+  }
+  "Map Decoder Ops" - {
+    import com.jpmc.codecs.Decoder.stringDecoder
+    val map = Json.Object(Map("1" -> Json.String("value 1"), "2" -> Json.String("value 2")))
+    "Successful decoding" in {
+      val expected = Right("value 1")
+      val result = Decoder.DocDecoderOps(map).decodeMap("1")
+      assert(expected == result)
+    }
+    "Failure decoding" in {
+      val expected = Left(DecoderErr("Unable to find value at key = 3"))
+      val result = Decoder.DocDecoderOps(map).decodeMap("3")
+      assert(expected == result)
+    }
+  }
+
 }

--- a/codecs/src/test/scala/EncoderTests.scala
+++ b/codecs/src/test/scala/EncoderTests.scala
@@ -1,13 +1,114 @@
 package com.jpmc.codecs
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import com.jpmc.codecs.Encoder.User
+import com.jpmc.json.Json
+import org.scalatest.freespec.AnyFreeSpec
 
-class EncoderTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
-  test("Some test") {
-    forAll { str: String =>
-      str should be(str)
+import java.time.LocalDate
+
+class EncoderTests extends AnyFreeSpec {
+
+  "Boolean Encoder" in {
+    val booleanTrue = true
+    val result = Encoder.encode(booleanTrue)
+    val expected = Json.Boolean(true)
+    assert(result == expected)
+  }
+
+  "String Encoder" in {
+    val stringExample = "John Doe"
+    val result = Encoder.encode(stringExample)
+    val expected = Json.String("John Doe")
+    assert(result == expected)
+  }
+
+  "Integer Encoder" in {
+    val numberExample = 10
+    val result = Encoder.encode(numberExample)
+    val expected = Json.Number(10)
+    assert(result == expected)
+  }
+
+  "Date Encoder" in {
+    val dateExample = LocalDate.of(2012, 10, 1)
+    val result = Encoder.encode(dateExample)
+    val expected = Json.String("2012-10-01")
+    assert(result == expected)
+  }
+
+    "Tuple2 Encoder" in {
+      val example: Tuple2[String, Int] = ("John Doe", 100)
+      val result = Encoder.encode(example)
+      val expected =
+        Json.Object(
+          Map(
+            "1" -> Json.String("John Doe"),
+            "2" -> Json.Number(100)
+          )
+        )
+      assert(result == expected)
     }
+
+    "Tuple3 Encoder" in {
+      val example: Tuple3[String, Int, Boolean] = ("John Doe", 100, false)
+      val result = Encoder.encode(example)
+      val expected =
+        Json.Object(
+          Map(
+            "1" -> Json.String("John Doe"),
+            "2" -> Json.Number(100),
+            "3" -> Json.Boolean(false)
+          )
+        )
+      assert(result == expected)
+    }
+
+  "List Encoder" in {
+    val example = List("A", "B", "C", "D")
+    val result = Encoder.encode(example)
+    val expected = Json.Array(List(Json.String("A"), Json.String("B"), Json.String("C"),Json.String("D")))
+    assert(result == expected)
+  }
+
+  "Vector Encoder" in {
+    val example = Vector("A", "B", "C", "D")
+    val result = Encoder.encode(example)
+    val expected = Json.Array(List(Json.String("A"), Json.String("B"), Json.String("C"), Json.String("D")))
+    assert(result == expected)
+  }
+
+  "Option Encoder - Some" in {
+    val example: Option[Int] = Some(10)
+    val result = Encoder.encode(example)
+    val expected = Json.Number(10)
+    assert(result == expected)
+  }
+
+  "Option Encoder - None" in {
+    val example: Option[Int] = None
+    val result = Encoder.encode(example)
+    val expected = Json.Null
+    assert(result == expected)
+  }
+
+  "Either Encoder Left case - Int, Int" in {
+    val example: Either[Int, Int] = Left(4)
+    val result = Encoder.encode(example)
+    val expected = Json.Object(Map("left" -> Json.Number(4)))
+    assert(result == expected)
+  }
+
+  "Either Encoder Right case - Int, Int" in {
+    val example: Either[Int, Int] = Right(4)
+    val result = Encoder.encode(example)
+    val expected = Json.Object(Map("right" -> Json.Number(4)))
+    assert(result == expected)
+  }
+
+  "User encoded correctly" in {
+    val example = User("Monica", 24, User.Kind.Guest)
+    val result = Encoder.encode(example)
+    val expected = Json.Object(Map("name" -> Json.String("Monica"), "age" -> Json.Number(24), "kind" -> Json.String("Guest")))
+    assert(result == expected)
   }
 }

--- a/json/src/main/scala/Json.scala
+++ b/json/src/main/scala/Json.scala
@@ -1,1 +1,67 @@
 package com.jpmc.json
+
+sealed trait Json extends Product with Serializable
+
+object Json {
+
+  case class String(str: java.lang.String) extends Json
+
+  case class Boolean(value: java.lang.Boolean) extends Json
+
+  case class Number(num: Int) extends Json
+
+  case object Null extends Json
+
+  def apply(str: java.lang.String): Json = String(str)
+
+  def apply(bool: java.lang.Boolean): Json = Boolean(bool)
+
+  def apply(num: Int): Json = Number(num)
+
+  sealed trait Doc extends Json
+
+  case class Array(data: List[Json]) extends Doc
+
+  case class Object(data: Map[java.lang.String, Json]) extends Doc
+
+  def apply(data: Json*): Doc = Array(data.toList)
+
+  def prettyPrint(json: Json): java.lang.String = {
+    val quotes = "\""
+    json match {
+      case jsonDoc: Doc => prettyPrintDoc(jsonDoc)
+      case Json.String(str) => quotes + str + quotes
+      case Json.Boolean(bool) => bool.toString
+      case Json.Number(num) => num.toString
+      case Json.Null => "null"
+    }
+  }
+
+  private def prettyPrintDoc(jsonDoc: Doc): java.lang.String = {
+    val separator = ", "
+    val openSquare = "["
+    val closeSquare = "]"
+    val quotes = "\""
+    val colon = ": "
+    val openCurly = "{"
+    val closeCurly = "}"
+    jsonDoc match {
+      case Array(data) =>
+        data.map(prettyPrint).mkString(openSquare, separator, closeSquare)
+      case Object(data) =>
+        data.map {
+          case (key, value) => s"$quotes$key$quotes$colon${prettyPrint(value)}"
+        }.mkString(openCurly, separator, closeCurly)
+    }
+  }
+
+  def removeNullValues(jsonDoc: Doc): Doc = {
+    jsonDoc match {
+      case Array(_) => jsonDoc
+      case Object(data) => Object(data = data.collect {
+        case (key, obj: Json.Object) => key -> removeNullValues(obj)
+        case (key, json: Json) if json != Null => key -> json
+      })
+    }
+  }
+}

--- a/json/src/test/scala/JsonTests.scala
+++ b/json/src/test/scala/JsonTests.scala
@@ -1,13 +1,57 @@
 package com.jpmc.json
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.freespec.AnyFreeSpec
+import Json._
 
-class JsonTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matchers {
-  test("Some test") {
-    forAll { str: String =>
-      str should be(str)
+class JsonTests extends AnyFreeSpec {
+  "Pretty printing of Docs with Nulls" - {
+    "Object works" in {
+      val jsonObject = Object(Map(
+        "name" -> String("Monica"),
+        "age" -> Number(24),
+        "items" -> Array(List(String("glasses"), Null, Boolean(true))),
+        "addressInfo" -> Object(Map(
+          "streetName" -> String("Sun Street"),
+          "country" -> String("UK"),
+          "county" -> Null
+        ))
+      ))
+      val printed = prettyPrint(jsonObject)
+      val expected = """{"name": "Monica", "age": 24, "items": ["glasses", null, true], "addressInfo": {"streetName": "Sun Street", "country": "UK", "county": null}}"""
+      assert(printed == expected)
+    }
+    "Array works" in {
+      val jsonArray = Array(List(Number(123), Boolean(false), String("Hello arr!"), Null))
+      val printed = prettyPrint(jsonArray)
+      val expected = """[123, false, "Hello arr!", null]"""
+      assert(printed == expected)
+    }
+  }
+  "Pretty printing of Docs with Nulls removed" - {
+    val jsonNulls = Object(Map(
+      "obj1" -> Object(Map(
+        "null1" -> Null,
+        "obj2" -> Object(Map(
+          "null2" -> Null,
+          "list" -> Array(List(Null, String("entryToList")))
+        ))
+      ))
+    ))
+    val json = Object(Map(
+      "obj1" -> Object(Map(
+        "obj2" -> Object(Map(
+          "list" -> Array(List(Null, String("entryToList")))
+        ))
+      ))
+    ))
+    val removed = removeNullValues(jsonNulls)
+    "removing nulls works" in {
+      assert(removed == json)
+    }
+    "printing works" in {
+      val printed = prettyPrint(removed)
+      val expected = """{"obj1": {"obj2": {"list": [null, "entryToList"]}}}"""
+      assert(printed == expected)
     }
   }
 }


### PR DESCRIPTION
The purpose of this PR is to provide a decoding implementation from JSON to type A.

Changes include the respective decoders for the encoder implementation in [this PR](https://github.com/monmcguigan/scala-training/pull/2), and tests to verify the decoding is working as expected.

The tests cover both the successful and failure decoding cases. 